### PR TITLE
chore: tidy forward declarations & headers

### DIFF
--- a/krep.c
+++ b/krep.c
@@ -80,29 +80,7 @@ void print_usage(const char *program_name);
 double get_time(void);
 void prepare_bad_char_table(const char *pattern, size_t pattern_len,
                            int *bad_char_table, bool case_sensitive);
-uint64_t boyer_moore_search(const char *text, size_t text_len,
-                           const char *pattern, size_t pattern_len,
-                           bool case_sensitive);
-uint64_t kmp_search(const char *text, size_t text_len,
-                    const char *pattern, size_t pattern_len,
-                    bool case_sensitive);
-uint64_t rabin_karp_search(const char *text, size_t text_len,
-                          const char *pattern, size_t pattern_len,
-                          bool case_sensitive);
-#ifdef __SSE4_2__
-uint64_t simd_search(const char *text, size_t text_len,
-                    const char *pattern, size_t pattern_len,
-                    bool case_sensitive);
-#endif
-#ifdef __AVX2__
-uint64_t avx2_search(const char *text, size_t text_len,
-                    const char *pattern, size_t pattern_len,
-                    bool case_sensitive);
-#endif
 void* search_thread(void *arg);
-int search_file(const char *filename, const char *pattern, size_t pattern_len, bool case_sensitive,
-               bool count_only, int thread_count);
-int search_string(const char *pattern, size_t pattern_len, const char *text, bool case_sensitive);
 
 /**
  * Get current time with high precision for performance measurement

--- a/krep.h
+++ b/krep.h
@@ -11,7 +11,11 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <stdlib.h>
+#include <stddef.h>
+
+int search_file(const char *filename, const char *pattern, size_t pattern_len, bool case_sensitive,
+               bool count_only, int thread_count);
+int search_string(const char *pattern, size_t pattern_len, const char *text, bool case_sensitive);
 
 /* Search algorithm function declarations */
 uint64_t boyer_moore_search(const char *text, size_t text_len,
@@ -37,9 +41,5 @@ uint64_t avx2_search(const char *text, size_t text_len,
                     const char *pattern, size_t pattern_len,
                     bool case_sensitive);
 #endif
-
-/* Helper function declaration */
-void prepare_bad_char_table(const char *pattern, size_t pattern_len,
-                           int *bad_char_table, bool case_sensitive);
 
 #endif /* KREP_H */


### PR DESCRIPTION
- search algorithms' declaration is already present in the header file
  purely preference--less LoC. unless, is there a reason they're doubled?

- move top-level search functions to header
  future goals could include compiling as a library;
  for now, it exposes the abi in the header

- `prepare_bad_char_table` is only used in `boyer_moore_search`
  doesn't look generalizable

- stddef over stdlib
  we only need size_t defined in the header