### PR TITLE
feat: Introduce ARM Neon-accelerated search

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ https://dev.to/daviducolo/introducing-krep-building-a-high-performance-string-se
   - Boyer-Moore-Horspool algorithm for general-purpose efficient pattern matching
   - Knuth-Morris-Pratt (KMP) algorithm optimized for short patterns
   - Rabin-Karp algorithm for longer pattern lengths
-  - SIMD acceleration on compatible hardware (SSE4.2, AVX2)
-  
+  - SIMD acceleration on compatible hardware (SSE4.2, AVX2, and ARM NEON)
+
 - **Maximum performance**
   - Memory-mapped file I/O for optimal throughput
   - Multi-threaded parallel search for large files
@@ -89,7 +89,7 @@ krep -s "Hello" "Hello world"
 
 - **Memory-mapped I/O**: Avoids costly read() system calls
 - **Optimized algorithms**: Uses multiple string-matching algorithms optimized for different scenarios
-- **SIMD acceleration**: Utilizes SSE4.2 or AVX2 when available
+- **SIMD acceleration**: Utilizes SSE4.2, AVX2, or ARM Neon when available
 - **Multi-threading**: Processes large files in parallel chunks
 - **Minimal allocations**: Reduces memory overhead and fragmentation
 
@@ -119,7 +119,7 @@ Performance compared to standard tools (searching a 1GB text file for a common p
 
 3. **Memory efficiency**: Uses memory-mapped I/O to leverage the operating system's page cache
 
-4. **Hardware acceleration**: Automatically detects and utilizes SSE4.2 and AVX2 instructions when available
+4. **Hardware acceleration**: Automatically detects and utilizes SSE4.2, AVX2 and ARM Neon instructions when available
 
 ## Testing
 

--- a/krep.h
+++ b/krep.h
@@ -42,4 +42,10 @@ uint64_t avx2_search(const char *text, size_t text_len,
                     bool case_sensitive);
 #endif
 
+#ifdef __ARM_NEON
+uint64_t neon_search(const char *text, size_t text_len,
+                    const char *pattern, size_t pattern_len,
+                    bool case_sensitive);
+#endif
+
 #endif /* KREP_H */

--- a/test/test_krep.c
+++ b/test/test_krep.c
@@ -37,31 +37,31 @@ static int tests_failed = 0;
  */
 void test_basic_search(void) {
     printf("\n=== Basic Search Tests ===\n");
-    
+
     const char *haystack = "The quick brown fox jumps over the lazy dog";
-    
+
     /* Test common cases */
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, true) == 1, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, true) == 1,
                "Boyer-Moore finds 'quick' once");
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "fox", 3, true) == 1, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "fox", 3, true) == 1,
                "Boyer-Moore finds 'fox' once");
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "cat", 3, true) == 0, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "cat", 3, true) == 0,
                "Boyer-Moore doesn't find 'cat'");
-    
+
     /* Test KMP algorithm */
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "quick", 5, true) == 1, 
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "quick", 5, true) == 1,
                "KMP finds 'quick' once");
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "fox", 3, true) == 1, 
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "fox", 3, true) == 1,
                "KMP finds 'fox' once");
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "cat", 3, true) == 0, 
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "cat", 3, true) == 0,
                "KMP doesn't find 'cat'");
-    
+
     /* Test Rabin-Karp algorithm */
-    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "quick", 5, true) == 1, 
+    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "quick", 5, true) == 1,
                 "Rabin-Karp finds 'quick' once");
-    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "fox", 3, true) == 1, 
+    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "fox", 3, true) == 1,
                 "Rabin-Karp finds 'fox' once");
-    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "cat", 3, true) == 0, 
+    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "cat", 3, true) == 0,
                 "Rabin-Karp doesn't find 'cat'");
 }
 
@@ -70,44 +70,44 @@ void test_basic_search(void) {
  */
 void test_edge_cases(void) {
     printf("\n=== Edge Cases Tests ===\n");
-    
+
     const char *haystack = "aaaaaaaaaaaaaaaaa";
-    
+
     /* Test single character patterns */
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "a", 1, true) == 17, 
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "a", 1, true) == 17,
                "KMP finds 17 occurrences of 'a'");
-    
+
     /* Test empty pattern and haystack */
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "", 0, true) == 0, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "", 0, true) == 0,
                "Empty pattern gives 0 matches");
-    TEST_ASSERT(boyer_moore_search("", 0, "test", 4, true) == 0, 
+    TEST_ASSERT(boyer_moore_search("", 0, "test", 4, true) == 0,
                "Empty haystack gives 0 matches");
-    
+
     /* Test matching at start and end */
-    TEST_ASSERT(kmp_search("abcdef", 6, "abc", 3, true) == 1, 
+    TEST_ASSERT(kmp_search("abcdef", 6, "abc", 3, true) == 1,
                "Match at start is found");
-    TEST_ASSERT(kmp_search("abcdef", 6, "def", 3, true) == 1, 
+    TEST_ASSERT(kmp_search("abcdef", 6, "def", 3, true) == 1,
                "Match at end is found");
-    
+
     /* Test overlapping patterns */
     const char *overlap_text = "abababa"; // Has 2 non-overlapping "aba" or 3 overlapping
     printf("Testing overlapping patterns: '%s' with pattern 'aba'\n", overlap_text);
-    
+
     uint64_t aba_bm = boyer_moore_search(overlap_text, strlen(overlap_text), "aba", 3, true);
     uint64_t aba_kmp = kmp_search(overlap_text, strlen(overlap_text), "aba", 3, true);
     uint64_t aba_rk = rabin_karp_search(overlap_text, strlen(overlap_text), "aba", 3, true);
-    
-    printf("  Boyer-Moore: %llu, KMP: %llu, Rabin-Karp: %llu matches\n", 
+
+    printf("  Boyer-Moore: %llu, KMP: %llu, Rabin-Karp: %llu matches\n",
            (unsigned long long)aba_bm, (unsigned long long)aba_kmp, (unsigned long long)aba_rk);
-    
+
     TEST_ASSERT(aba_bm >= 2, "Boyer-Moore finds at least 2 occurrences of 'aba'");
     TEST_ASSERT(aba_kmp >= 2, "KMP finds at least 2 occurrences of 'aba'");
     TEST_ASSERT(aba_rk >= 2, "Rabin-Karp finds at least 2 occurrences of 'aba'");
-    
+
     /* Test with repeating pattern 'aa' */
     const char *aa_text = "aaaaa"; // Has 4 overlapping "aa" or 2 non-overlapping
     uint64_t aa_count = rabin_karp_search(aa_text, strlen(aa_text), "aa", 2, true);
-    printf("Sequence 'aaaaa' with pattern 'aa': Rabin-Karp found %llu occurrences\n", 
+    printf("Sequence 'aaaaa' with pattern 'aa': Rabin-Karp found %llu occurrences\n",
            (unsigned long long)aa_count);
     TEST_ASSERT(aa_count >= 2, "Rabin-Karp finds at least 2 occurrences of 'aa'");
 }
@@ -117,26 +117,26 @@ void test_edge_cases(void) {
  */
 void test_case_insensitive(void) {
     printf("\n=== Case-Insensitive Tests ===\n");
-    
+
     const char *haystack = "The Quick Brown Fox Jumps Over The Lazy Dog";
-    
+
     /* Compare case sensitive vs insensitive */
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, true) == 0, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, true) == 0,
                "Case-sensitive doesn't find 'quick'");
-    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, false) == 1, 
+    TEST_ASSERT(boyer_moore_search(haystack, strlen(haystack), "quick", 5, false) == 1,
                "Case-insensitive finds 'quick'");
-    
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "FOX", 3, true) == 0, 
+
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "FOX", 3, true) == 0,
                "Case-sensitive doesn't find 'FOX'");
-    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "FOX", 3, false) == 1, 
+    TEST_ASSERT(kmp_search(haystack, strlen(haystack), "FOX", 3, false) == 1,
                "Case-insensitive finds 'FOX'");
-    
+
     /* Check case-insensitive search with different algorithms */
-    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "dog", 3, true) == 0, 
+    TEST_ASSERT(rabin_karp_search(haystack, strlen(haystack), "dog", 3, true) == 0,
                "Case-sensitive doesn't find 'dog'");
-    
+
     uint64_t dog_count = rabin_karp_search(haystack, strlen(haystack), "dog", 3, false);
-    printf("Case-insensitive Rabin-Karp search for 'dog' in '%s': %llu matches\n", 
+    printf("Case-insensitive Rabin-Karp search for 'dog' in '%s': %llu matches\n",
            haystack, (unsigned long long)dog_count);
     TEST_ASSERT(dog_count == 1, "Case-insensitive finds 'Dog'");
 }
@@ -146,26 +146,26 @@ void test_case_insensitive(void) {
  */
 void test_repeated_patterns(void) {
     printf("\n=== Repeated Patterns Tests ===\n");
-    
+
     /* Test with repeating patterns with overlapping patterns */
     const char *test_str = "ababababa";
-    
+
     uint64_t bm_count = boyer_moore_search(test_str, strlen(test_str), "aba", 3, true);
     uint64_t kmp_count = kmp_search(test_str, strlen(test_str), "aba", 3, true);
     uint64_t rk_count = rabin_karp_search(test_str, strlen(test_str), "aba", 3, true);
-    
+
     printf("Repeated pattern 'aba' in 'ababababa':\n");
-    printf("  Boyer-Moore: %llu\n  KMP: %llu\n  Rabin-Karp: %llu\n", 
+    printf("  Boyer-Moore: %llu\n  KMP: %llu\n  Rabin-Karp: %llu\n",
            (unsigned long long)bm_count, (unsigned long long)kmp_count, (unsigned long long)rk_count);
-    
+
     // Allow more flexible test assertions that pass as long as we find at least some matches
     TEST_ASSERT(bm_count > 0, "Boyer-Moore finds occurrences of 'aba'");
     TEST_ASSERT(kmp_count > 0, "KMP finds occurrences of 'aba'");
     TEST_ASSERT(rk_count > 0, "Rabin-Karp finds occurrences of 'aba'");
-    
+
     /* Test with sequence of repeats */
     const char *repeated = "abc abc abc abc abc";
-    TEST_ASSERT(boyer_moore_search(repeated, strlen(repeated), "abc", 3, true) == 5, 
+    TEST_ASSERT(boyer_moore_search(repeated, strlen(repeated), "abc", 3, true) == 5,
                "Boyer-Moore finds 5 occurrences of 'abc'");
 }
 
@@ -174,7 +174,7 @@ void test_repeated_patterns(void) {
  */
 void test_performance(void) {
     printf("\n=== Performance Tests ===\n");
-    
+
     /* Create a large string for testing */
     const int size = 1000000;
     char *large_text = (char *)malloc(size + 1);  // +1 for null terminator
@@ -182,25 +182,25 @@ void test_performance(void) {
         printf("Failed to allocate memory for performance test\n");
         return;
     }
-    
+
     /* Fill with repeating pattern to ensure matches */
     for (int i = 0; i < size; i++) {
         large_text[i] = 'a' + (i % 26);
     }
     large_text[size] = '\0';
-    
+
     /* Insert the pattern at known positions */
     const char *pattern = "performancetest";
     size_t pattern_len = strlen(pattern);
-    
+
     /* Make sure we're inserting at valid positions */
     size_t pos1 = 1000;
     size_t pos2 = size - 10000;  // Well before the end to avoid buffer overruns
-    
+
     if (pos1 + pattern_len <= size && pos2 + pattern_len <= size) {
         memcpy(large_text + pos1, pattern, pattern_len);
         memcpy(large_text + pos2, pattern, pattern_len);
-        
+
         /* Debug output to verify insertions */
         printf("Inserted '%s' at positions %zu and %zu\n", pattern, pos1, pos2);
         printf("Text near first insertion: '%.15s...'\n", large_text + pos1);
@@ -208,38 +208,38 @@ void test_performance(void) {
     } else {
         printf("Warning: Invalid pattern insertion positions\n");
     }
-    
+
     /* Measure time for each algorithm */
     clock_t start, end;
     double time_boyer, time_kmp, time_rabin;
     uint64_t matches_bm, matches_kmp, matches_rk;
-    
+
     start = clock();
     matches_bm = boyer_moore_search(large_text, size, pattern, pattern_len, true);
     end = clock();
     time_boyer = ((double)(end - start)) / CLOCKS_PER_SEC;
-    
+
     start = clock();
     matches_kmp = kmp_search(large_text, size, pattern, pattern_len, true);
     end = clock();
     time_kmp = ((double)(end - start)) / CLOCKS_PER_SEC;
-    
+
     start = clock();
     matches_rk = rabin_karp_search(large_text, size, pattern, pattern_len, true);
     end = clock();
     time_rabin = ((double)(end - start)) / CLOCKS_PER_SEC;
-    
-    printf("Boyer-Moore search time: %f seconds (found %llu matches)\n", 
+
+    printf("Boyer-Moore search time: %f seconds (found %llu matches)\n",
            time_boyer, (unsigned long long)matches_bm);
-    printf("KMP search time: %f seconds (found %llu matches)\n", 
+    printf("KMP search time: %f seconds (found %llu matches)\n",
            time_kmp, (unsigned long long)matches_kmp);
-    printf("Rabin-Karp search time: %f seconds (found %llu matches)\n", 
+    printf("Rabin-Karp search time: %f seconds (found %llu matches)\n",
            time_rabin, (unsigned long long)matches_rk);
-    
+
     TEST_ASSERT(matches_bm == 2, "Boyer-Moore found exactly 2 occurrences");
     TEST_ASSERT(matches_kmp == 2, "KMP found exactly 2 occurrences");
     TEST_ASSERT(matches_rk == 2, "Rabin-Karp found exactly 2 occurrences");
-    
+
     free(large_text);
 }
 
@@ -248,15 +248,15 @@ void test_performance(void) {
  */
 void test_pathological_cases(void) {
     printf("\n=== Pathological Pattern Tests ===\n");
-    
+
     /* Test case 1: Pattern that repeats within itself */
     const char *haystack1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const char *pattern1 = "aaaaaa";
-    
+
     uint64_t count_bm = boyer_moore_search(haystack1, strlen(haystack1), pattern1, strlen(pattern1), true);
     uint64_t count_kmp = kmp_search(haystack1, strlen(haystack1), pattern1, strlen(pattern1), true);
 
-    printf("Repeating pattern '%s' in string of %zu 'a's: BM=%llu, KMP=%llu\n", 
+    printf("Repeating pattern '%s' in string of %zu 'a's: BM=%llu, KMP=%llu\n",
            pattern1, strlen(haystack1), (unsigned long long)count_bm, (unsigned long long)count_kmp);
 
     TEST_ASSERT(count_bm > 0, "Boyer-Moore handles repeating pattern");
@@ -265,27 +265,27 @@ void test_pathological_cases(void) {
     /* Test case 2: Pattern with near-misses to trigger backtracking */
     const char *haystack2 = "ababababababababababababababababc";
     const char *pattern2 = "abababababababababc";
-    
+
     /* This should only match once at the end but causes backtracking */
     uint64_t count_backtrack_bm = boyer_moore_search(haystack2, strlen(haystack2), pattern2, strlen(pattern2), true);
     uint64_t count_backtrack_kmp = kmp_search(haystack2, strlen(haystack2), pattern2, strlen(pattern2), true);
-    
-    printf("Backtracking test with pattern ending in 'c': BM=%llu, KMP=%llu\n", 
+
+    printf("Backtracking test with pattern ending in 'c': BM=%llu, KMP=%llu\n",
            (unsigned long long)count_backtrack_bm, (unsigned long long)count_backtrack_kmp);
-    
+
     TEST_ASSERT(count_backtrack_bm == 1, "Boyer-Moore correctly handles backtracking case");
     TEST_ASSERT(count_backtrack_kmp == 1, "KMP correctly handles backtracking case");
 
     /* Test case 3: Multiple matches with different offsets */
     const char *haystack3 = "abcabcabcabcabcabcabc";
     const char *pattern3 = "abca";
-    
+
     uint64_t count_offset_bm = boyer_moore_search(haystack3, strlen(haystack3), pattern3, strlen(pattern3), true);
     uint64_t count_offset_kmp = kmp_search(haystack3, strlen(haystack3), pattern3, strlen(pattern3), true);
-    
-    printf("Pattern '%s' with shifting positions: BM=%llu, KMP=%llu\n", 
+
+    printf("Pattern '%s' with shifting positions: BM=%llu, KMP=%llu\n",
            pattern3, (unsigned long long)count_offset_bm, (unsigned long long)count_offset_kmp);
-    
+
     TEST_ASSERT(count_offset_bm >= 5, "Boyer-Moore finds matches at different offsets");
     TEST_ASSERT(count_offset_kmp >= 5, "KMP finds matches at different offsets");
 }
@@ -295,45 +295,45 @@ void test_pathological_cases(void) {
  */
 void test_boundary_conditions(void) {
     printf("\n=== Buffer Boundary Tests ===\n");
-    
+
     /* Test case 1: Match exactly at the beginning */
     const char *start_text = "matchxxxxxxxxxxxxx";
-    TEST_ASSERT(boyer_moore_search(start_text, strlen(start_text), "match", 5, true) == 1, 
+    TEST_ASSERT(boyer_moore_search(start_text, strlen(start_text), "match", 5, true) == 1,
                 "Boyer-Moore finds match at start of buffer");
-    TEST_ASSERT(kmp_search(start_text, strlen(start_text), "match", 5, true) == 1, 
+    TEST_ASSERT(kmp_search(start_text, strlen(start_text), "match", 5, true) == 1,
                 "KMP finds match at start of buffer");
-    
+
     /* Test case 2: Match exactly at the end */
     const char *end_text = "xxxxxxxxxxxmatch";
-    TEST_ASSERT(boyer_moore_search(end_text, strlen(end_text), "match", 5, true) == 1, 
+    TEST_ASSERT(boyer_moore_search(end_text, strlen(end_text), "match", 5, true) == 1,
                 "Boyer-Moore finds match at end of buffer");
-    TEST_ASSERT(kmp_search(end_text, strlen(end_text), "match", 5, true) == 1, 
+    TEST_ASSERT(kmp_search(end_text, strlen(end_text), "match", 5, true) == 1,
                 "KMP finds match at end of buffer");
-    
+
     /* Test case 3: Pattern exactly equals the text */
     const char *exact_text = "exactmatch";
-    TEST_ASSERT(boyer_moore_search(exact_text, strlen(exact_text), "exactmatch", 10, true) == 1, 
+    TEST_ASSERT(boyer_moore_search(exact_text, strlen(exact_text), "exactmatch", 10, true) == 1,
                 "Boyer-Moore handles pattern equal to entire text");
-    TEST_ASSERT(kmp_search(exact_text, strlen(exact_text), "exactmatch", 10, true) == 1, 
+    TEST_ASSERT(kmp_search(exact_text, strlen(exact_text), "exactmatch", 10, true) == 1,
                 "KMP handles pattern equal to entire text");
-    
+
     /* Test case 4: Pattern longer than text */
-    TEST_ASSERT(boyer_moore_search("short", 5, "longpattern", 11, true) == 0, 
+    TEST_ASSERT(boyer_moore_search("short", 5, "longpattern", 11, true) == 0,
                 "Boyer-Moore handles pattern longer than text");
-    TEST_ASSERT(kmp_search("short", 5, "longpattern", 11, true) == 0, 
+    TEST_ASSERT(kmp_search("short", 5, "longpattern", 11, true) == 0,
                 "KMP handles pattern longer than text");
-    
+
     /* Test case 5: Match at each position in a string */
     const char *every_pos = "aXaXaXaXaX";
     uint64_t count_a_bm = boyer_moore_search(every_pos, strlen(every_pos), "a", 1, true);
     uint64_t count_a_kmp = kmp_search(every_pos, strlen(every_pos), "a", 1, true);
     uint64_t count_X_bm = boyer_moore_search(every_pos, strlen(every_pos), "X", 1, true);
     uint64_t count_X_kmp = kmp_search(every_pos, strlen(every_pos), "X", 1, true);
-    
-    printf("Alternating pattern test 'aXaXaXaXaX': a(BM=%llu, KMP=%llu), X(BM=%llu, KMP=%llu)\n", 
-           (unsigned long long)count_a_bm, (unsigned long long)count_a_kmp, 
+
+    printf("Alternating pattern test 'aXaXaXaXaX': a(BM=%llu, KMP=%llu), X(BM=%llu, KMP=%llu)\n",
+           (unsigned long long)count_a_bm, (unsigned long long)count_a_kmp,
            (unsigned long long)count_X_bm, (unsigned long long)count_X_kmp);
-    
+
     TEST_ASSERT(count_a_bm == 5, "Boyer-Moore finds all 'a' instances");
     TEST_ASSERT(count_a_kmp == 5, "KMP finds all 'a' instances");
     TEST_ASSERT(count_X_bm == 5, "Boyer-Moore finds all 'X' instances");
@@ -345,56 +345,56 @@ void test_boundary_conditions(void) {
  */
 void test_advanced_case_insensitive(void) {
     printf("\n=== Advanced Case-Insensitive Tests ===\n");
-    
+
     /* Test case 1: Mixed case in both pattern and text */
     const char *mixed_text = "ThIs Is A mIxEd CaSe TeXt";
     const char *mixed_pattern = "MiXeD cAsE";
-    
+
     TEST_ASSERT(boyer_moore_search(mixed_text, strlen(mixed_text), mixed_pattern, strlen(mixed_pattern), true) == 0,
                "Boyer-Moore case-sensitive correctly fails with mixed case");
     TEST_ASSERT(boyer_moore_search(mixed_text, strlen(mixed_text), mixed_pattern, strlen(mixed_pattern), false) == 1,
                "Boyer-Moore case-insensitive finds mixed case pattern");
-    
+
     /* Test case 2: All variations of case for a pattern */
     const char *variations_text = "TEST test Test tEsT teSt";
     const char *test_pattern = "test";
-    
+
     uint64_t case_sens_count = boyer_moore_search(variations_text, strlen(variations_text), test_pattern, strlen(test_pattern), true);
     uint64_t case_insens_count = boyer_moore_search(variations_text, strlen(variations_text), test_pattern, strlen(test_pattern), false);
-    
-    printf("Case variations test: Found %llu case-sensitive matches and %llu case-insensitive matches\n", 
+
+    printf("Case variations test: Found %llu case-sensitive matches and %llu case-insensitive matches\n",
            (unsigned long long)case_sens_count, (unsigned long long)case_insens_count);
-    
+
     TEST_ASSERT(case_sens_count == 1, "Boyer-Moore finds only exact case match");
     TEST_ASSERT(case_insens_count == 5, "Boyer-Moore case-insensitive finds all variations");
-    
+
     /* Test case 3: Non-ASCII characters */
     /* Note: This may not work in all environments due to character encoding differences */
     setlocale(LC_ALL, "en_US.UTF-8");  // Set locale to support extended characters
-    
+
     const char *extended_text = "Café café CAFÉ";
     const char *extended_pattern = "café";
-    
+
     uint64_t extended_sens_count = boyer_moore_search(extended_text, strlen(extended_text), extended_pattern, strlen(extended_pattern), true);
     uint64_t extended_insens_count = boyer_moore_search(extended_text, strlen(extended_text), extended_pattern, strlen(extended_pattern), false);
-    
-    printf("Extended character test with 'café': Found %llu case-sensitive and %llu case-insensitive\n", 
+
+    printf("Extended character test with 'café': Found %llu case-sensitive and %llu case-insensitive\n",
            (unsigned long long)extended_sens_count, (unsigned long long)extended_insens_count);
-    
+
     /* These might be system-dependent, so we'll just report but not fail the tests */
     if (extended_sens_count == 1) {
         printf("✓ PASS: Case-sensitive extended character matching works\n");
         tests_passed++;
     } else {
-        printf("? INFO: Case-sensitive extended character test returned %llu (expected 1)\n", 
+        printf("? INFO: Case-sensitive extended character test returned %llu (expected 1)\n",
                (unsigned long long)extended_sens_count);
     }
-    
+
     if (extended_insens_count >= 2) {
         printf("✓ PASS: Case-insensitive extended character matching works\n");
         tests_passed++;
     } else {
-        printf("? INFO: Case-insensitive extended character test returned %llu (expected >= 2)\n", 
+        printf("? INFO: Case-insensitive extended character test returned %llu (expected >= 2)\n",
                (unsigned long long)extended_insens_count);
     }
 }
@@ -404,7 +404,7 @@ void test_advanced_case_insensitive(void) {
  */
 void test_varying_pattern_lengths(void) {
     printf("\n=== Pattern Length Variation Tests ===\n");
-    
+
     /* Create a long haystack with predictable content */
     const int haystack_size = 10000;
     char *haystack = (char *)malloc(haystack_size + 1);
@@ -412,53 +412,53 @@ void test_varying_pattern_lengths(void) {
         printf("Failed to allocate memory for pattern length tests\n");
         return;
     }
-    
+
     /* Generate a haystack with repeating "abcdefghijklmnopqrstuvwxyz0123456789" */
     const char *alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
     size_t alphabet_len = strlen(alphabet);
-    
+
     for (int i = 0; i < haystack_size; i++) {
         haystack[i] = alphabet[i % alphabet_len];
     }
     haystack[haystack_size] = '\0';
-    
+
     /* Test patterns of increasing lengths */
     const int max_test_length = 50;
     char pattern[max_test_length + 1];
     double times_bm[max_test_length];
     double times_kmp[max_test_length];
-    
+
     printf("Testing search performance with increasing pattern lengths:\n");
     printf("Length | Boyer-Moore (s) | KMP (s)\n");
     printf("-----------------------------------\n");
-    
+
     for (int len = 1; len <= max_test_length; len += 5) {
         /* Create pattern of this length from the start of the haystack */
         strncpy(pattern, haystack, len);
         pattern[len] = '\0';
-        
+
         /* Time Boyer-Moore search */
         clock_t start = clock();
         uint64_t bm_count = boyer_moore_search(haystack, haystack_size, pattern, len, true);
         clock_t end = clock();
         times_bm[len] = ((double)(end - start)) / CLOCKS_PER_SEC;
-        
+
         /* Time KMP search */
         start = clock();
         uint64_t kmp_count = kmp_search(haystack, haystack_size, pattern, len, true);
         end = clock();
         times_kmp[len] = ((double)(end - start)) / CLOCKS_PER_SEC;
-        
-        printf("%6d | %14.6f | %8.6f | Matches: BM=%llu, KMP=%llu\n", 
-               len, times_bm[len], times_kmp[len], 
+
+        printf("%6d | %14.6f | %8.6f | Matches: BM=%llu, KMP=%llu\n",
+               len, times_bm[len], times_kmp[len],
                (unsigned long long)bm_count, (unsigned long long)kmp_count);
-        
+
         /* Both algorithms should find the same number of matches */
         char message[100];
         sprintf(message, "Boyer-Moore and KMP find same number of matches with length %d", len);
         TEST_ASSERT(bm_count == kmp_count, message);
     }
-    
+
     free(haystack);
 }
 
@@ -467,7 +467,7 @@ void test_varying_pattern_lengths(void) {
  */
 void test_stress(void) {
     printf("\n=== Stress Test ===\n");
-    
+
     /* Create a very large string (50MB) */
     const size_t size = 50 * 1024 * 1024;
     char *large_text = (char *)malloc(size + 1);
@@ -475,50 +475,50 @@ void test_stress(void) {
         printf("Failed to allocate memory for stress test (this is normal for systems with limited RAM)\n");
         return;
     }
-    
+
     printf("Successfully allocated %zu MB for stress test\n", size / (1024 * 1024));
-    
+
     /* Fill with pseudorandom data using a fixed seed for reproducibility */
     srand(42);
     for (size_t i = 0; i < size; i++) {
         large_text[i] = 'a' + (rand() % 26);
     }
     large_text[size] = '\0';
-    
+
     /* Insert known patterns at specific intervals */
     const char *pattern = "UNIQUEPATTERN";
     size_t pattern_len = strlen(pattern);
     int expected_matches = 0;
-    
+
     for (size_t i = 1000000; i < size; i += 5000000) {
         if (i + pattern_len < size) {
             memcpy(large_text + i, pattern, pattern_len);
             expected_matches++;
         }
     }
-    
+
     printf("Inserted %d instances of pattern '%s' in the text\n", expected_matches, pattern);
-    
+
     /* Perform searches with each algorithm and verify results */
     clock_t start = clock();
     uint64_t bm_count = boyer_moore_search(large_text, size, pattern, pattern_len, true);
     clock_t end = clock();
     double time_bm = ((double)(end - start)) / CLOCKS_PER_SEC;
-    
+
     start = clock();
     uint64_t kmp_count = kmp_search(large_text, size, pattern, pattern_len, true);
     end = clock();
     double time_kmp = ((double)(end - start)) / CLOCKS_PER_SEC;
-    
+
     printf("Stress test results on %zu MB text:\n", size / (1024 * 1024));
-    printf("  Boyer-Moore: %llu matches in %.3f seconds (%.2f MB/s)\n", 
+    printf("  Boyer-Moore: %llu matches in %.3f seconds (%.2f MB/s)\n",
            (unsigned long long)bm_count, time_bm, size / (1024.0 * 1024.0) / time_bm);
-    printf("  KMP: %llu matches in %.3f seconds (%.2f MB/s)\n", 
+    printf("  KMP: %llu matches in %.3f seconds (%.2f MB/s)\n",
            (unsigned long long)kmp_count, time_kmp, size / (1024.0 * 1024.0) / time_kmp);
-    
+
     TEST_ASSERT(bm_count == expected_matches, "Boyer-Moore finds correct number of matches in stress test");
     TEST_ASSERT(kmp_count == expected_matches, "KMP finds correct number of matches in stress test");
-    
+
     free(large_text);
 }
 
@@ -527,25 +527,25 @@ void test_stress(void) {
  */
 int main(void) {
     printf("Running enhanced krep tests...\n");
-    
+
     /* Original tests */
     test_basic_search();
     test_edge_cases();
     test_case_insensitive();
     test_repeated_patterns();
     test_performance();
-    
+
     /* Additional tests */
     test_pathological_cases();
     test_boundary_conditions();
     test_advanced_case_insensitive();
     test_varying_pattern_lengths();
     test_stress();
-    
+
     printf("\n=== Test Summary ===\n");
     printf("Tests passed: %d\n", tests_passed);
     printf("Tests failed: %d\n", tests_failed);
     printf("Total tests: %d\n", tests_passed + tests_failed);
-    
+
     return tests_failed == 0 ? 0 : 1;
 }

--- a/test/test_krep.h
+++ b/test/test_krep.h
@@ -32,4 +32,10 @@ uint64_t avx2_search(const char *text, size_t text_len,
                    bool case_sensitive);
 #endif
 
+#ifdef __ARM_NEON
+uint64_t neon_search(const char *text, size_t text_len,
+                    const char *pattern, size_t pattern_len,
+                    bool case_sensitive);
+#endif
+
 #endif /* TEST_KREP_H */


### PR DESCRIPTION
- Introduced the `neon_search` function for high-performance string matching on ARM processors using Neon SIMD instructions
- Precomputes a lowercase pattern for case-insensitive searches using a lookup table (`lower_table`), storing it in a 16-byte buffer
- Utilizes NEON's `vld1q_u8_x2` for loading two 16-byte blocks of text at a time and `vceqq_u8` for vectorized comparison against the pattern vector (`pattern_vec`)
- Implements fast case conversion via `vqtbl1q_u8` to convert text characters to lowercase using the precomputed lookup table during case-insensitive searches
- Processes text in chunks of 32 bytes, leveraging `__builtin_prefetch` to prefetch the next chunk for better memory locality
- Uses `vgetq_lane_u64` to extract match results from the comparison vector and checks if the pattern fully matches using a bitmask
- Falls back to a scalar comparison loop when there are fewer than 32 bytes remaining in the text for pattern matching
- Included optimizations for boundary handling to skip overlapping matches at thread boundaries in the parallel search implementation